### PR TITLE
Fix OG image path and alt text typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<meta property="og:description" content="Portafolio de Neil Aular, programador Full Stack JS" />
 	<meta name="author" content="Neil Aular" />
 	<meta property="og:title" content="Neil Portafolio" />
-	<meta property="og:image" content="./assets/imagenes/yo-portafolio-meta.jpg">
+        <meta property="og:image" content="https://nxl22.github.io/assets/imagenes/yo-portafolio-meta.jpg">
 	<meta property="og:url" content="https://nxl22.github.io/" />
 	<link rel="canonical" href="https://nxl22.github.io/" />
 	<meta name="google-site-verification" content="sAAdLAHbcNgNtkoSwe-Tm4KbyCVM6EUm1wsYtFwlTVA" />
@@ -125,7 +125,7 @@
 
 			<div class="card">
 				<h3>Proyecto de Modo Mío 🍕 </h3>
-				<img src="./assets/imagenes/pizzeria.jpeg" decoding="async" loading="lazy" alt="Poyecto Modo Mío">
+                                <img src="./assets/imagenes/pizzeria.jpeg" decoding="async" loading="lazy" alt="Proyecto Modo Mío">
 
 				<p class="texto-card">La información de las pizzas se obtiene a través de un JSON, y mediante el Context
 					se muestra el precio total del pedido</p>


### PR DESCRIPTION
## Summary
- fix OG image to use absolute URL
- correct a typo in the alt text for the Pizzeria project card

## Testing
- `node script/date.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f257af0dc8328861307e6c1ff012b