### PR TITLE
Revert BEM changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<meta property="og:description" content="Portafolio de Neil Aular, programador Full Stack JS" />
 	<meta name="author" content="Neil Aular" />
 	<meta property="og:title" content="Neil Portafolio" />
-	<meta property="og:image" content="./assets/imagenes/yo-portafolio-meta.jpg">
+	<meta property="og:image" content="https://nxl22.github.io/assets/imagenes/yo-portafolio-meta.jpg">
 	<meta property="og:url" content="https://nxl22.github.io/" />
 	<link rel="canonical" href="https://nxl22.github.io/" />
 	<meta name="google-site-verification" content="sAAdLAHbcNgNtkoSwe-Tm4KbyCVM6EUm1wsYtFwlTVA" />
@@ -125,7 +125,7 @@
 
 			<div class="card">
 				<h3>Proyecto de Modo Mío 🍕 </h3>
-				<img src="./assets/imagenes/pizzeria.jpeg" decoding="async" loading="lazy" alt="Poyecto Modo Mío">
+				<img src="./assets/imagenes/pizzeria.jpeg" decoding="async" loading="lazy" alt="Proyecto Modo Mío">
 
 				<p class="texto-card">La información de las pizzas se obtiene a través de un JSON, y mediante el Context
 					se muestra el precio total del pedido</p>


### PR DESCRIPTION
## Summary
- revert previous commit that changed CSS classes to BEM naming
- restore absolute OG image link and correct alt text for Modo Mío

## Testing
- `git status --short`
- `git merge-tree $(git merge-base work main) work main | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685f2678b3988328a4046b8a454b7ff9